### PR TITLE
Added check to make sure poem can only belong to collection owned by author

### DIFF
--- a/server/src/resolvers/Mutation.ts
+++ b/server/src/resolvers/Mutation.ts
@@ -34,6 +34,14 @@ export const Mutation: Resolvers["Mutation"] = {
   createPoem: async (_, { input }, { user, services }) => {
     await verifyUser({ user, authorService: services.authorService });
 
+    // make sure collection belongs to author
+    if(input.collectionId) {
+      const collection = await services.collectionService.getCollection({id: input.collectionId})
+      if (collection.authorId !== user.authorId) {
+        throw new Error(`cannot add poem to collection`)
+      }
+    }
+
     try {
       return services.poemService.createPoem({
         ...input,
@@ -129,6 +137,14 @@ export const Mutation: Resolvers["Mutation"] = {
   // Update
   updatePoem: async (_, { input }, { user, services }) => {
     await verifyUser({ user, authorService: services.authorService });
+
+    // make sure collection belongs to author
+    if (input.collectionId) {
+      const collection = await services.collectionService.getCollection({id: input.collectionId})
+      if (collection.authorId !== user.authorId) {
+        throw new Error(`cannot add poem to collection`)
+      }
+    }
 
     const poem = await services.poemService.getPoem({ id: input.poemId });
 

--- a/server/src/resolvers/__tests__/Author.test.ts
+++ b/server/src/resolvers/__tests__/Author.test.ts
@@ -41,6 +41,7 @@ describe("Graphql Author integration tests", () => {
   });
   afterAll(async () => {
     await testServer.cleanup();
+    await cache.delByPattern({ pattern: "*" });
   });
 
   test("poems, without pagination", async () => {

--- a/server/src/resolvers/__tests__/Collection.test.ts
+++ b/server/src/resolvers/__tests__/Collection.test.ts
@@ -43,6 +43,7 @@ describe("Graphql Mutation integration tests", () => {
   });
   afterAll(async () => {
     await testServer.cleanup();
+    await cache.delByPattern({ pattern: "*" });
   });
 
   test("author", async () => {

--- a/server/src/resolvers/__tests__/Comment.test.ts
+++ b/server/src/resolvers/__tests__/Comment.test.ts
@@ -38,6 +38,7 @@ describe("Graphql Mutation integration tests", () => {
   });
   afterAll(async () => {
     await testServer.cleanup();
+    await cache.delByPattern({ pattern: "*" });
   });
 
   test("poem", async () => {

--- a/server/src/resolvers/__tests__/FollowedAuthor.test.ts
+++ b/server/src/resolvers/__tests__/FollowedAuthor.test.ts
@@ -45,6 +45,7 @@ describe("Graphql Mutation integration tests", () => {
   });
   afterAll(async () => {
     await testServer.cleanup();
+    await cache.delByPattern({ pattern: "*" });
   });
 
   test("follower", async () => {

--- a/server/src/resolvers/__tests__/Like.test.ts
+++ b/server/src/resolvers/__tests__/Like.test.ts
@@ -28,6 +28,7 @@ describe("Graphql Mutation integration tests", () => {
   });
   afterAll(async () => {
     await testServer.cleanup();
+    await cache.delByPattern({ pattern: "*" });
   });
 
   test("author", async () => {

--- a/server/src/resolvers/__tests__/Poem.test.ts
+++ b/server/src/resolvers/__tests__/Poem.test.ts
@@ -36,6 +36,7 @@ describe("Graphql Mutation integration tests", () => {
   });
   afterAll(async () => {
     await testServer.cleanup();
+    await cache.delByPattern({ pattern: "*" });
   });
 
   test("author", async () => {

--- a/server/src/resolvers/__tests__/Query.test.ts
+++ b/server/src/resolvers/__tests__/Query.test.ts
@@ -63,6 +63,7 @@ describe("Graphql Query integration tests", () => {
   });
   afterAll(async () => {
     await testServer.cleanup();
+    await cache.delByPattern({ pattern: "*" });
   });
 
   test("poems, without filter or pagination, succeeds", async () => {

--- a/server/src/resolvers/__tests__/SavedPoem.test.ts
+++ b/server/src/resolvers/__tests__/SavedPoem.test.ts
@@ -42,6 +42,7 @@ describe("Graphql SavedPoem integration tests", () => {
   });
   afterAll(async () => {
     await testServer.cleanup();
+    await cache.delByPattern({ pattern: "*" });
   });
 
   test("author", async () => {


### PR DESCRIPTION
Modified updatePoem and createPoem resolvers to check if the collectionId provided as input belongs to the author of the poem